### PR TITLE
Implement periodic player reauthentication cycle

### DIFF
--- a/player/player.go
+++ b/player/player.go
@@ -228,3 +228,8 @@ func (p *Player) NormalizeTickets() {
 func (p *Player) HeartBeat() {
 	p.client.Write(protocol.NewClientMsgProtobuf(steamlang.EMsg_ClientHeartBeat, new(protobuf.CMsgClientHeartBeat)))
 }
+
+func (p *Player) Logoff() {
+	p.client.Write(protocol.NewClientMsgProtobuf(steamlang.EMsg_ClientLogOff, new(protobuf.CMsgClientLogOff)))
+	p.client.Disconnect()
+}


### PR DESCRIPTION
## Summary
- track players per server and the accounts they use so they can be recycled between authorization cycles
- refactor mirror startup to use startPlayersForServer and schedule a 6-minute ticker that logs off players and restarts sequential logons
- add player.Player.Logoff to send CMsgClientLogOff and disconnect the Steam client

## Testing
- GOPROXY=off go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68e104857fc8832483423e4107f6f516