### PR TITLE
Remove legacy config toggles and default to CS2 metadata

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
   "start_port": 27016,
-  "csgo_mod": false,
   "servers": [
     {
       "count": 1000,
@@ -13,7 +12,6 @@
       "region": "3",
       "secure": true,
       "tags": "wirstaff_inc",
-      "use_abuse": false,
       "description": "Wirstaff INC"
     }
   ]

--- a/server/server.go
+++ b/server/server.go
@@ -26,7 +26,6 @@ type Server struct {
 	region     string
 	port       uint32
 	bots       uint8
-	csgoMod    bool
 	tags       string
 
 	appid   uint32
@@ -82,11 +81,7 @@ func (s *Server) sendServerType() {
 	builder.GamePort = proto.Uint32(s.port)
 	builder.GameVersion = proto.String(s.version)
 
-	if s.csgoMod {
-		builder.GameDir = proto.String("csgo")
-	} else {
-		builder.GameDir = proto.String("cs2")
-	}
+	builder.GameDir = proto.String("cs2")
 
 	s.client.Write(protocol.NewClientMsgProtobuf(steamlang.EMsg_GSServerType, builder))
 }
@@ -106,14 +101,10 @@ func (s *Server) sendServerData() {
 	builder.Dedicated = proto.Bool(true)
 	builder.GameType = proto.String(s.tags)
 
-	if s.csgoMod {
-		builder.Product = proto.String("csgo")
-	} else {
-		builder.Product = proto.String("cs2")
-	}
+	builder.Product = proto.String("cs2")
 
 	builder.Region = proto.String(s.region)
-	builder.Gamedir = proto.String("csgo")
+	builder.Gamedir = proto.String("cs2")
 	builder.Os = proto.String("l")
 
 	s.client.Write(protocol.NewClientMsgProtobuf(steamlang.EMsg_AMGameServerUpdate, builder))
@@ -180,10 +171,6 @@ func (s *Server) SetPort(value uint32) {
 
 func (s *Server) SetBots(value uint8) {
 	s.bots = value
-}
-
-func (s *Server) SetCSGOMod(value bool) {
-	s.csgoMod = value
 }
 
 func (s *Server) SetTags(value string) {


### PR DESCRIPTION
## Summary
- refactor server startup helpers to drop the csgo_mod/use_abuse switches from the configuration
- simplify server metadata so it always reports the CS2 product without relying on a toggle
- update the sample config to remove the deprecated fields

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68e10eac8d308324bc57bd9aae5db389