### PR TITLE
Handle service shutdown via OS signals

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"wirstaff.com/mirrors/player"
 	"wirstaff.com/mirrors/server"
@@ -86,7 +87,10 @@ func main() {
 
 	go loadServers(config)
 
-	background()
+	quit := background()
+	sig := <-quit
+	log.Printf("Получен сигнал завершения: %s", sig)
+	signal.Stop(quit)
 }
 
 func loadServers(config *Config) {
@@ -229,16 +233,8 @@ func heartbeatLoop() {
 	}
 }
 
-func background() {
-	fmt.Println("Нажми 'q' + 'Enter' чтобы закрыть программу")
-
-	scanner := bufio.NewScanner(os.Stdin)
-	for scanner.Scan() {
-		exit := scanner.Text()
-		if exit == "q" {
-			break
-		} else {
-			fmt.Println("Нажми 'q' + 'Enter' чтобы закрыть программу")
-		}
-	}
+func background() chan os.Signal {
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	return quit
 }


### PR DESCRIPTION
## Summary
- replace the interactive shutdown prompt with OS signal handling
- block in `main` until a termination signal is received and log the shutdown

## Testing
- `go build ./...` *(fails: repository access requires network)*

------
https://chatgpt.com/codex/tasks/task_e_68e11adf18408324b6b968e79c5064aa