### PR TITLE
Remove legacy CSGO configuration flags

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
   "start_port": 27016,
-  "csgo_mod": false,
   "servers": [
     {
       "count": 1000,
@@ -13,7 +12,6 @@
       "region": "3",
       "secure": true,
       "tags": "wirstaff_inc",
-      "use_abuse": false,
       "description": "Wirstaff INC"
     }
   ]

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ import (
 type Config struct {
 	StartPort uint32    `json:"start_port"`
 	Servers   []Servers `json:"servers"`
-	CSGOMod   bool      `json:"csgo_mod"`
 }
 
 type Servers struct {
@@ -40,7 +39,6 @@ type Servers struct {
 	Secure        bool   `json:"secure"`
 	Tags          string `json:"tags"`
 	Description   string `json:"description"`
-	UseAbuse      bool   `json:"use_abuse"`
 }
 
 const (
@@ -187,12 +185,12 @@ func fetchSteamVersion() (string, error) {
 			startPort++
 			portMutex.Unlock()
 
-			go runMirror(item, token, port, config.CSGOMod)
+			go runMirror(item, token, port)
 		}
 	}
 }
 
-func runMirror(item Servers, token string, port uint32, csgoMod bool) {
+func runMirror(item Servers, token string, port uint32) {
 	s := server.New()
 	s.SetHostname(item.Hostname)
 	s.SetMap(item.Map)
@@ -201,7 +199,6 @@ func runMirror(item Servers, token string, port uint32, csgoMod bool) {
 	s.SetSecure(item.Secure)
 	s.SetRegion(item.Region)
 	s.SetBots(item.Bots)
-	s.SetCSGOMod(csgoMod)
 	s.SetTags(item.Tags)
 	s.Connect()
 
@@ -323,7 +320,7 @@ func startPlayersForServer(s *server.Server, item Servers) []*player.Player {
 			continue
 		}
 
-		if item.Bots > 0 || item.UseAbuse {
+		if item.Bots > 0 {
 			break
 		}
 	}
@@ -390,7 +387,7 @@ func removePlayer(target *player.Player) {
 	}
 }
 
-func runMirror(tmpl Servers, token string, port uint32, csgoMod bool, accountsMutex *sync.Mutex, accountsIdx *int) {
+func runMirror(tmpl Servers, token string, port uint32, accountsMutex *sync.Mutex, accountsIdx *int) {
 	srv := server.New()
 	srv.SetHostname(tmpl.Hostname)
 	srv.SetMap(tmpl.Map)
@@ -399,7 +396,6 @@ func runMirror(tmpl Servers, token string, port uint32, csgoMod bool, accountsMu
 	srv.SetSecure(tmpl.Secure)
 	srv.SetRegion(tmpl.Region)
 	srv.SetBots(tmpl.Bots)
-	srv.SetCSGOMod(csgoMod)
 	srv.SetTags(tmpl.Tags)
 	srv.SetVersion(getGameVersion())
 
@@ -457,7 +453,7 @@ func startPlayersForServer(srv *server.Server, tmpl Servers, accountsMutex *sync
 
 		startPlayer(srv, login, password)
 
-		if tmpl.Bots > 0 || tmpl.UseAbuse {
+		if tmpl.Bots > 0 {
 			break
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -26,7 +26,6 @@ type Server struct {
 	region     string
 	port       uint32
 	bots       uint8
-	csgoMod    bool
 	tags       string
 
 	appid   uint32
@@ -82,11 +81,7 @@ func (s *Server) sendServerType() {
 	builder.GamePort = proto.Uint32(s.port)
 	builder.GameVersion = proto.String(s.version)
 
-	if s.csgoMod {
-		builder.GameDir = proto.String("csgo")
-	} else {
-		builder.GameDir = proto.String("cs2")
-	}
+	builder.GameDir = proto.String("cs2")
 
 	s.client.Write(protocol.NewClientMsgProtobuf(steamlang.EMsg_GSServerType, builder))
 }
@@ -106,14 +101,10 @@ func (s *Server) sendServerData() {
 	builder.Dedicated = proto.Bool(true)
 	builder.GameType = proto.String(s.tags)
 
-	if s.csgoMod {
-		builder.Product = proto.String("csgo")
-	} else {
-		builder.Product = proto.String("cs2")
-	}
+	builder.Product = proto.String("cs2")
 
 	builder.Region = proto.String(s.region)
-	builder.Gamedir = proto.String("csgo")
+	builder.Gamedir = proto.String("cs2")
 	builder.Os = proto.String("l")
 
 	s.client.Write(protocol.NewClientMsgProtobuf(steamlang.EMsg_AMGameServerUpdate, builder))
@@ -180,10 +171,6 @@ func (s *Server) SetPort(value uint32) {
 
 func (s *Server) SetBots(value uint8) {
 	s.bots = value
-}
-
-func (s *Server) SetCSGOMod(value bool) {
-	s.csgoMod = value
 }
 
 func (s *Server) SetTags(value string) {


### PR DESCRIPTION
## Summary
- stop expecting the deprecated `csgo_mod` and `use_abuse` settings in the configuration and player startup logic
- always launch mirrors with the CS2 identifiers by default
- update the sample JSON config to match the streamlined schema

## Testing
- go test ./... *(fails: command hung in this environment and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68e139c6f4b483248eb682c705f25cdc